### PR TITLE
escape pipe character in Union rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ handlebars.registerPartial('arrayOf', 'Array[]<{{#with (typeObject this)}}{{> (t
 handlebars.registerPartial('objectOf', 'Object[#]<{{#with (typeObject this)}}{{> (typePartial value) value}}{{/with}}>');
 handlebars.registerPartial('instanceOf', '{{#with (typeObject this)}}{{value}}{{/with}}');
 handlebars.registerPartial('enum', 'Enum({{#with (typeObject this)}}{{#each value}}{{{this.value}}}{{#unless @last}},{{/unless}}{{/each}}{{/with}})');
-handlebars.registerPartial('union', 'Union<{{#with (typeObject this)}}{{#each value}}{{> (typePartial this) this}}{{#unless @last}}|{{/unless}}{{/each}}{{/with}}>');
+handlebars.registerPartial('union', 'Union<{{#with (typeObject this)}}{{#each value}}{{> (typePartial this) this}}{{#unless @last}} \\| {{/unless}}{{/each}}{{/with}}>');
 
 handlebars.registerHelper('typeObject', getType);
 


### PR DESCRIPTION
The output for Union prop-types includes `|` characters to separate type options. This is an issue as some markdown engines (Github's for sure, possibly Gitlab's according to [this](https://github.com/OriR/react-docgen-markdown-renderer/issues/3#issuecomment-327460606)) as they interpret it as a table column delimiter.

This PR just escapes the pipe symbol when rendering Union types (`\|` instead of `|`). This fixed the rendering problem on Github for me.