### PR TITLE
Add option to choose how to name components

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ This property is optional.</br>
 Represents the base directory where all of your components live.</br>
 It's used when creating a markdown link at the top of the file.
 
+##### componentsName `String`
+This property is optional.</br>
+Choose how the components should be named in the documentation: either with the display name (`displayName`) or with the file name (`fileName`).</br>
+Default `displayName`.
+
 ##### template `String`
 `react-docgen-markdown-renderer` uses [Handlebarsjs](http://handlebarsjs.com) to generate the markdown template.</br>
 Which means that you can use all the partials and helpers that `react-docgen-markdown-renderer` defines in your own template!</br>

--- a/README.md
+++ b/README.md
@@ -40,11 +40,6 @@ This property is optional.</br>
 Represents the base directory where all of your components live.</br>
 It's used when creating a markdown link at the top of the file.
 
-##### componentsName `String`
-This property is optional.</br>
-Choose how the components should be named in the documentation: either with the display name (`displayName`) or with the file name (`fileName`).</br>
-Default `displayName`.
-
 ##### template `String`
 `react-docgen-markdown-renderer` uses [Handlebarsjs](http://handlebarsjs.com) to generate the markdown template.</br>
 Which means that you can use all the partials and helpers that `react-docgen-markdown-renderer` defines in your own template!</br>

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ class ReactDocGenMarkdownRenderer {
   constructor(options) {
     this.options = Object.assign({
       componentsBasePath: process.cwd(),
+      componentsName: 'displayName',
       template: defaultTemplate
     }, options);
 
@@ -138,7 +139,7 @@ class ReactDocGenMarkdownRenderer {
   }
 
   render(file, docs, composes) {
-    const componentName = path.basename(file, path.extname(file));
+    const componentName = this.options.componentsName === 'fileName' ? path.basename(file, path.extname(file)) : docs.displayName;
 
     const sortedProps = flattenProps(docs.props);
 

--- a/index.js
+++ b/index.js
@@ -130,7 +130,6 @@ class ReactDocGenMarkdownRenderer {
   constructor(options) {
     this.options = Object.assign({
       componentsBasePath: process.cwd(),
-      componentsName: 'displayName',
       template: defaultTemplate
     }, options);
 
@@ -139,7 +138,7 @@ class ReactDocGenMarkdownRenderer {
   }
 
   render(file, docs, composes) {
-    const componentName = this.options.componentsName === 'fileName' ? path.basename(file, path.extname(file)) : docs.displayName;
+    const componentName = docs.displayName ? docs.displayName : path.basename(file, path.extname(file));
 
     const sortedProps = flattenProps(docs.props);
 


### PR DESCRIPTION
As discussed in #9 , here is a small PR to add the `componentsName` option to choose how to name components.

It allows to choose between:
- `displayName` (default)
- `fileName`